### PR TITLE
[codex] update public status checks

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -3,17 +3,26 @@ owner: aerialytic # Your GitHub organization or username, where this repository 
 repo: status # The name of this repository
 
 sites:
-  - name: Aerialytic AI
+  - name: Aerialytic Website
     url: https://aerialytic.ai
-  - name: GraphQL API
-    url: https://aerialytic.ai
-  - name: CRM
+  - name: Production CRM Portal
     url: https://portal.aisolar.design
-  - name: IPv6 test
-    url: forwardemail.net
-    port: 80
-    check: "tcp-ping"
-    ipv6: true
+  - name: Production CRM Main Alias
+    url: https://portal.main.aerialytic.dev
+  - name: Production CRM API Auth Boundary
+    url: https://portal.aisolar.design/api/user/self/
+    expectedStatusCodes:
+      - 401
+  - name: Production Imagery Service
+    url: https://imagery.platform.aisolar.design/healthcheck
+  - name: Next CRM Portal
+    url: https://portal.next.aerialytic.dev
+  - name: Next CRM API Auth Boundary
+    url: https://portal.next.aerialytic.dev/api/user/self/
+    expectedStatusCodes:
+      - 401
+  - name: Next Imagery Service
+    url: https://imagery.platform.next.aerialytic.dev/healthcheck
 
 status-website:
   # Add your custom domain name, or remove the `cname` line if you don't have a domain
@@ -27,10 +36,12 @@ status-website:
   navbar:
     - title: Status
       href: /
-    - title: CRM
+    - title: Website
+      href: https://aerialytic.ai
+    - title: Production CRM
       href: https://portal.aisolar.design
-    - title: Platform
-      href: https://platform.aerialytic.ai
+    - title: Next CRM
+      href: https://portal.next.aerialytic.dev
 
 # Upptime also supports notifications, assigning issues, and more
 # See https://upptime.js.org/docs/configuration


### PR DESCRIPTION
## Summary

- replace stale/misleading Upptime checks with current public Aerialytic checks
- add production CRM portal, main alias, API auth-boundary, and imagery health checks
- add next CRM portal, API auth-boundary, and imagery health checks
- remove the duplicated GraphQL check that pointed at the marketing site and the unrelated IPv6 test
- update public status-page navbar links to Website, Production CRM, and Next CRM

## Base branch note

The Status repo does not currently have a develop branch. This branch is based on the freshly fetched `master` branch, which is the repo default/source branch.

## Validation

- `yq .sites | length .upptimerc.yml` returned 8 configured checks
- verified live public endpoint status codes:
  - `https://aerialytic.ai/` -> 200
  - `https://portal.aisolar.design/` -> 200
  - `https://portal.main.aerialytic.dev/` -> 200
  - `https://portal.aisolar.design/api/user/self/` -> 401 expected auth boundary
  - `https://imagery.platform.aisolar.design/healthcheck` -> 200
  - `https://portal.next.aerialytic.dev/` -> 200
  - `https://portal.next.aerialytic.dev/api/user/self/` -> 401 expected auth boundary
  - `https://imagery.platform.next.aerialytic.dev/healthcheck` -> 200

## Follow-up

This keeps the public status page customer-safe. App-level monitors for bad `/null` routes, raw tracebacks, iframe lead 5xx/499, and workflow failures should be added as internal log/Kubernetes alerts or exposed later once customer-facing wording is agreed.